### PR TITLE
Support other UUID generators in auto_add.

### DIFF
--- a/docs/_ext/pgfields_docs.py
+++ b/docs/_ext/pgfields_docs.py
@@ -4,12 +4,12 @@ from sphinx.util.compat import Directive
 
 
 def setup(app):
-    app.add_directive('versionadded', VersionDirective)
-    app.add_directive('versionchanged', VersionDirective)
+    app.add_directive('versionadded', NewInVersionDirective)
+    app.add_directive('versionmodified', ChangedInVersionDirective)
     app.add_config_value('next_version', '1.4', True)
 
 
-class VersionDirective(Directive):
+class NewInVersionDirective(Directive):
     """Directive class for adding version notes."""
 
     has_content = True
@@ -17,6 +17,7 @@ class VersionDirective(Directive):
     optional_arguments = 1
     final_argument_whitespace = True
     option_spec = {}
+    _prefix = 'New in'
 
     def run(self):
         """Translate the directive to the appropriate markup."""
@@ -43,7 +44,7 @@ class VersionDirective(Directive):
         #   (and does so in a totally undocumented way). Sigh.
         kwargs = {}
         if not os.environ.get('READTHEDOCS', None):
-            kwargs['text'] = 'New in %s.' % version_string
+            kwargs['text'] = '%s %s.' % (self._prefix, version_string)
 
         # Create and append the node.
         node = addnodes.versionmodified(**kwargs)
@@ -56,3 +57,7 @@ class VersionDirective(Directive):
 
         # Done. Return the answer.
         return answer
+
+
+class ChangedInVersionDirective(NewInVersionDirective):
+    _prefix = 'Changed in'

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -181,6 +181,8 @@ the field options `available to all fields`_.
 
 **auto_add**
 
+.. versionmodified:: 1.4
+
 Normally, the UUIDField works like any other Field subclass; you are
 expected to provide a value, and the value is saved to the database directly.
 
@@ -199,6 +201,19 @@ integers::
     >>> legolas.save()
     >>> legolas.id
     UUID('b1f12115-3337-4ec0-acb9-1bcf63e44477')
+
+As of django-pgfields 1.4, it is *also* possible to use ``auto_add`` to
+generate a UUID using an algorithm other than ``uuid.uuid4``.  Instead of
+sending in ``True``, send in any callable which takes no arguments and
+reliably returns a UUID.
+
+For instance, the following field instantiation would cause a version 1 UUID
+to be used instead::
+
+    from django_pg import models
+    import uuid
+
+    id = models.UUID(auto_add=uuid.uuid1, primary_key=True)
 
 **coerce_to**
 


### PR DESCRIPTION
This commit adds the ability to specify `UUIDField.auto_add` as a callable, rather than just boolean True. If a callable is specified, it is called with no arguments.

This allows for:

``` python
id = models.UUIDField(auto_add=uuid.uuid1, primary_key=True)
```

...or similar flexibility.

Closes #4.
