### PR TITLE
Add deconstruct methods to fields with custom keywords

### DIFF
--- a/django_pg/models/fields/array.py
+++ b/django_pg/models/fields/array.py
@@ -21,11 +21,11 @@ class ArrayField(models.Field):
     def __init__(self, of=models.IntegerField, **kwargs):
         # The `of` argument is a bit tricky once we need compatibility
         # with South.
-        # 
+        #
         # South can't store a field, and the eval it performs doesn't
         # put enough things in the context to use South's internal
         # "get field" function (`BaseMigration.gf`).
-        # 
+        #
         # Therefore, we need to be able to accept a South triple of our
         # sub-field and hook into South to get the correct thing back.
         if isinstance(of, tuple) and south_installed:
@@ -45,6 +45,11 @@ class ArrayField(models.Field):
 
         # Now pass the rest of the work to the Field superclass.
         super(ArrayField, self).__init__(**kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super(ArrayField, self).deconstruct()
+        kwargs['of'] = self.of
+        return name, path, args, kwargs
 
     def create_type(self, connection):
         if hasattr(self.of, 'create_type'):

--- a/django_pg/models/fields/uuid.py
+++ b/django_pg/models/fields/uuid.py
@@ -51,6 +51,12 @@ class UUIDField(Field):
         # Now pass the rest of the work to CharField.
         super(UUIDField, self).__init__(**kwargs)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(UUIDField, self).deconstruct()
+        kwargs['auto_add'] = self._auto_add
+        kwargs['coerce_to'] = self._coerce_to
+        return name, path, args, kwargs
+
     def db_type(self, connection):
         return 'uuid'
 

--- a/django_pg/utils/south.py
+++ b/django_pg/utils/south.py
@@ -1,8 +1,14 @@
 from __future__ import absolute_import, unicode_literals
-
+import django
 
 try:
     import south
     south_installed = True
 except ImportError:
     south_installed = False
+
+
+if django.VERSION[1] < 7:
+    using_new_migrations = False
+else:
+    using_new_migrations = True

--- a/tests/arrays/tests.py
+++ b/tests/arrays/tests.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import, unicode_literals
+from django.db import models
 from django.test import TestCase
+from django.utils.unittest import skipIf
+from django_pg.utils.south import using_new_migrations
 from tests.arrays.models import Place
 
 
@@ -92,3 +95,16 @@ class ArrayTests(TestCase):
         from django.db import connection
         field = Place._meta.get_field('residents')
         self.assertEqual(field.create_type_sql(connection), '')
+
+    @skipIf(not using_new_migrations, 'not using new migrations')
+    def test_array_deconstruct_method(self):
+        from django_pg.models import ArrayField
+        name, path, args, kwargs = ArrayField().deconstruct()
+        self.assertTrue(isinstance(kwargs['of'], models.IntegerField))
+
+    @skipIf(not using_new_migrations, 'not using new migrations')
+    def test_array_deconstruct_method_with_changed_field_type(self):
+        from django.db import models
+        field = Place._meta.get_field('residents')
+        name, path, args, kwargs = field.deconstruct()
+        self.assertTrue(isinstance(kwargs['of'], models.CharField))

--- a/tests/jsont/tests.py
+++ b/tests/jsont/tests.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, unicode_literals
-from django.core.exceptions import ValidationError
-from django.db import connection
 from django.test import TestCase
+from django.utils.unittest import skipIf
 from django_pg.models.fields.json import JSONField
+from django_pg.utils.south import using_new_migrations
 from tests.jsont.models import Song
 import math
 
@@ -87,7 +87,7 @@ class JSONSuite(TestCase):
         properly returns empty list.
         """
         # Assert that a retreival of a default value from a database
-        # save returns what we expect. 
+        # save returns what we expect.
         song = Song.objects.get(title='All that is Gold does not Glitter')
         self.assertEqual(song.sample_lines, [])
 
@@ -189,6 +189,19 @@ class JSONSuite(TestCase):
         song = Song(title='Something', sample_lines='')
         self.assertIsInstance(song.sample_lines, list)
         self.assertEqual(song.sample_lines, [])
+
+    @skipIf(not using_new_migrations, 'not using new migrations')
+    def test_default_type_is_not_returned_in_deconstruct(self):
+        field = Song._meta.get_field('data')
+        name, path, args, kwargs = field.deconstruct()
+        self.assertNotIn('type', kwargs)
+
+    @skipIf(not using_new_migrations, 'not using new migrations')
+    def test_setting_type_is_reflected_in_deconstruct(self):
+        field = Song._meta.get_field('sample_lines')
+        name, path, args, kwargs = field.deconstruct()
+        self.assertEqual(kwargs['type'], list)
+
 
 class SupportSuite(TestCase):
     """Suite for testing more rarely-accessed aspects of JSON fields."""


### PR DESCRIPTION
Fields that are adding keyword arguments to custom fields require a `deconstruct` method to make the keywords available in the corresponding migration(s). The [Django 1.7 documentation provides more details](https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#field-deconstruction).

Without the `deconstruct` method, the custom keywords are not added to the migrations and are therefore ignored when the migrations are run. In my case, the migrations failed because `auto_add` was not set during the migrations of the `UUIDField`.

I have added `deconstruct` methods to th `ArrayField`, `JSONField` and `UUIDField` adding the custom keywords accordingly. Please take a look and let me know if you are happy with that or have any suggestions to improving it.

Oh, and thanks for a great Django app :thumbsup:.
