### PR TITLE
Fixing arrays of UUID

### DIFF
--- a/tests/arrays/models.py
+++ b/tests/arrays/models.py
@@ -5,3 +5,6 @@ from django_pg import models
 class Place(models.Model):
     name = models.CharField(max_length=20)
     residents = models.ArrayField(of=models.CharField(max_length=40))
+
+class UUIDArray(models.Model):
+    uuids = models.ArrayField(of=models.UUIDField())

--- a/tests/arrays/tests.py
+++ b/tests/arrays/tests.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
+import uuid
 from django.test import TestCase
-from tests.arrays.models import Place
+from tests.arrays.models import Place, UUIDArray
 
 
 class ArrayTests(TestCase):
@@ -84,6 +85,17 @@ class ArrayTests(TestCase):
     def test_empty_array(self):
         place = Place.objects.get(name='Mordor')
         self.assertEqual(place.residents, [])
+
+    def test_uuid_array(self):
+        uuids = [uuid.uuid4() for i in range(10)]
+        u = UUIDArray.objects.create(uuids=uuids)
+        u = UUIDArray.objects.get(pk=u.pk)
+        self.assertEqual(u.uuids, uuids)
+
+    def test_empty_uuid_array(self):
+        u = UUIDArray.objects.create(uuids=[])
+        u = UUIDArray.objects.get(pk=u.pk)
+        self.assertEqual(u.uuids, [])
 
     def test_create_type_sql(self):
         """Establish that, on an array of a standard field type,

--- a/tests/uuidt/tests.py
+++ b/tests/uuidt/tests.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 from django.test import TestCase
 from django.utils.unittest import skipIf
 from django_pg import models
-from django_pg.models.fields.uuid import UUIDAdapter, UUIDField
+from django_pg.models.fields.uuid import UUIDField
 from django.test.utils import override_settings
 from django_pg.utils.south import south_installed
 from tests.uuidt.models import Movie, Game, Book, SomethingElse
@@ -131,17 +131,6 @@ class NullUUIDSuite(TestCase):
         with self.assertRaises(AttributeError):
             class Thing(models.Model):
                 uuid = models.UUIDField(blank=True)
-
-
-class SupportSuite(TestCase):
-    """Test support classes."""
-
-    def test_uuid_adapter(self):
-        """Ensure that the UUIDAdapter object will fail if it receives
-        something other than a `uuid.UUID` object.
-        """
-        with self.assertRaises(TypeError):
-            adapter = UUIDAdapter('01234567-0123-0123-0123-0123456789ab')
 
 
 @override_settings(DJANGOPG_DEFAULT_UUID_PK=True)


### PR DESCRIPTION
The psycopg2 adapter being used for UUIDField didn't handle edge cases
around arrays well and, in the case of an empty array of UUIDs, was not
being registered. psycopg2 itself already includes a UUID adapter, so
this commit switches to using it and registers the adapter at the module
level.

Regression tests have been added to ensure that arrays of UUIDs (both
populated and empty) continue to work.
